### PR TITLE
Use doautocmd to re-fire BufRead autocmds

### DIFF
--- a/autoload/address_handler/address_handler.vim
+++ b/autoload/address_handler/address_handler.vim
@@ -54,7 +54,7 @@ function! address_handler#address_handler#ReadCmd(match)
         if l:open_cmd =~ "\ve(>|d|di|dit)@="
             silent exe "file ".l:path
         else
-            bw! 
+            bw!
         endif
     endif
 
@@ -93,5 +93,6 @@ function! address_handler#address_handler#ReadCmd(match)
         endif
     endif
 
+    execute "doautocmd BufRead *.".fnamemodify(l:path, ":e")
     filetype detect
 endfunction


### PR DESCRIPTION
Otherwise any BufRead autocmd defined on the file's extension will not
be fired