### PR TITLE
Fix buffer life-cycle events

### DIFF
--- a/autoload/address_handler/address_handler.vim
+++ b/autoload/address_handler/address_handler.vim
@@ -17,7 +17,7 @@ function! address_handler#address_handler#Init()
     if !exists("g:plan9#address_handler#gnu_col")
         let g:plan9#address_handler#gnu_col = 1
     endif
-    au! BufReadCmd *:* call address_handler#address_handler#ReadCmd(fnameescape(expand("<amatch>")))
+    au! BufReadCmd *:* ++nested call address_handler#address_handler#ReadCmd(fnameescape(expand("<amatch>")))
 endfunction
 
 function! address_handler#address_handler#ReadCmd(match)
@@ -94,5 +94,6 @@ function! address_handler#address_handler#ReadCmd(match)
     endif
 
     execute "doautocmd BufRead *.".fnamemodify(l:path, ":e")
+    execute "doautocmd BufWinEnter *.".fnamemodify(l:path, ":e")
     filetype detect
 endfunction


### PR DESCRIPTION
Make the BufReadCmd a ++nested autocommand so that all relevant events
are triggered (important for external plugins listening to buffer events
via autocommands).

Also fire the BufWinEnter via doautocmd after BufRead. This is the next
event in the buffer life-cycle that is fired (:help BufRead and its
reference to BufWinEnter)